### PR TITLE
8-change-reorder-function-to-take-values-instead-of-item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to get all items from a listing ([#2](https://github.com/khalyomede/reorder-before-after/issues/2)).
 - Ability to set a callback to apply the order on your value ([#1](https://github.com/khalyomede/reorder-before-after/issues/10)).
 - Support for PHP 8.1 ([#10](https://github.com/khalyomede/reorder-before-after/issues/10)).
+- Reordering using the raw value instead of passing an Item ([#8](https://github.com/khalyomede/reorder-before-after/issues/8)).
 
 ## [0.1.0] - 2023-01-11
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $listing->push(new Item("chair", 2));
 $listing->push(new Item("table", 3));
 $listing->push(new Item("book", 4));
 
-$listing->reorder($book, Placement::Before, $table);
+$listing->reorder("book", Placement::Before, "table");
 
 assert($listing->find("bag")->order === 1);
 assert($listing->find("chair")->order === 2);

--- a/src/Listing.php
+++ b/src/Listing.php
@@ -46,19 +46,22 @@ final class Listing
         $this->items[] = $item;
     }
 
-    public function reorder(Item $item, Placement $placement, Item $reference): void
+    public function reorder(mixed $value, Placement $placement, mixed $reference): void
     {
         $this->sortItems();
 
-        if ($item !== $reference) {
+        if ($value !== $reference) {
+            $item = $this->find($value);
+            $referenceItem = $this->find($reference);
+
             $this->removeItem($item);
 
             if ($placement->isBefore()) {
-                $left = $this->itemsBefore($reference);
-                $right = $this->itemsAfter($reference, included: true);
+                $left = $this->itemsBefore($referenceItem);
+                $right = $this->itemsAfter($referenceItem, included: true);
             } else {
-                $left = $this->itemsBefore($reference, included: true);
-                $right = $this->itemsAfter($reference);
+                $left = $this->itemsBefore($referenceItem, included: true);
+                $right = $this->itemsAfter($referenceItem);
             }
 
             $this->items = array_merge($left, [$item], $right);

--- a/tests/ReorderTest.php
+++ b/tests/ReorderTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Khalyomede\ReorderBeforeAfter\Exceptions\InvalidApplyWithCallbackException;
+use Khalyomede\ReorderBeforeAfter\Exceptions\ItemNotFoundException;
 use Khalyomede\ReorderBeforeAfter\Item;
 use Khalyomede\ReorderBeforeAfter\Listing;
 use Khalyomede\ReorderBeforeAfter\Placement;
@@ -15,7 +16,7 @@ test("can reorder string item before another one in the middle of the list", fun
     $list->push(new Item("book", 3));
     $list->push(new Item("bag", 4));
 
-    $list->reorder($list->find("bag"), Placement::Before, $list->find("table"));
+    $list->reorder("bag", Placement::Before, "table");
 
     expect($list->find("bag")->order)->toBe(1);
     expect($list->find("table")->order)->toBe(2);
@@ -30,7 +31,7 @@ test("can reorder string item after another one in the middle of the list", func
     $list->push(new Item("chair", 3));
     $list->push(new Item("book", 4));
 
-    $list->reorder($list->find("table"), Placement::After, $list->find("chair"));
+    $list->reorder("table", Placement::After, "chair");
 
     expect($list->find("bag")->order)->toBe(1);
     expect($list->find("chair")->order)->toBe(2);
@@ -45,7 +46,7 @@ test("can reorder string item before another one in the end of the list", functi
     $list->push(new Item("chair", 3));
     $list->push(new Item("table", 4));
 
-    $list->reorder($list->find("bag"), Placement::Before, $list->find("chair"));
+    $list->reorder("bag", Placement::Before, "chair");
 
     expect($list->find("book")->order)->toBe(1);
     expect($list->find("bag")->order)->toBe(2);
@@ -60,7 +61,7 @@ test("can reorder string item after another one in the end of the list", functio
     $list->push(new Item("chair", 3));
     $list->push(new Item("table", 4));
 
-    $list->reorder($list->find("book"), Placement::After, $list->find("table"));
+    $list->reorder("book", Placement::After, "table");
 
     expect($list->find("bag")->order)->toBe(1);
     expect($list->find("chair")->order)->toBe(2);
@@ -75,7 +76,7 @@ test("can reorder string item before another one in the begining of the list", f
     $list->push(new Item("chair", 3));
     $list->push(new Item("table", 4));
 
-    $list->reorder($list->find("chair"), Placement::Before, $list->find("bag"));
+    $list->reorder("chair", Placement::Before, "bag");
 
     expect($list->find("chair")->order)->toBe(1);
     expect($list->find("bag")->order)->toBe(2);
@@ -90,7 +91,7 @@ test("can reorder string item after another one in the begining of the list", fu
     $list->push(new Item("chair", 3));
     $list->push(new Item("table", 4));
 
-    $list->reorder($list->find("chair"), Placement::After, $list->find("bag"));
+    $list->reorder("chair", Placement::After, "bag");
 
     expect($list->find("bag")->order)->toBe(1);
     expect($list->find("chair")->order)->toBe(2);
@@ -105,7 +106,7 @@ test("does nothing if reordering string item before itself", function (): void {
     $list->push(new Item("chair", 3));
     $list->push(new Item("table", 4));
 
-    $list->reorder($list->find("bag"), Placement::Before, $list->find("bag"));
+    $list->reorder("bag", Placement::Before, "bag");
 
     expect($list->find("bag")->order)->toBe(1);
     expect($list->find("book")->order)->toBe(2);
@@ -120,7 +121,7 @@ test("does nothing if reordering string item after itself", function (): void {
     $list->push(new Item("chair", 3));
     $list->push(new Item("table", 4));
 
-    $list->reorder($list->find("bag"), Placement::After, $list->find("bag"));
+    $list->reorder("bag", Placement::After, "bag");
 
     expect($list->find("bag")->order)->toBe(1);
     expect($list->find("book")->order)->toBe(2);
@@ -202,7 +203,7 @@ test("can apply the order using a callback", function (): void {
         $product->order = $item->order;
     });
 
-    $listing->reorder($listing->find($table), Placement::Before, $listing->find($chair));
+    $listing->reorder($table, Placement::Before, $chair);
 
     expect($bag->order)->toBe(1);
     expect($book->order)->toBe(2);
@@ -232,4 +233,22 @@ test("throws exception if the apply with a callback without Item type hint", fun
     expect(function () use ($listing): void {
         $listing->applyWith(fn (Product $item): int => 1);
     })->toThrow(InvalidApplyWithCallbackException::class, "Your callback must be type hinted with " . Item::class);
+});
+
+test("throws exception if reordering an item that does not exist", function (): void {
+    $listing = new Listing();
+
+    expect(function () use ($listing): void {
+        $listing->reorder("bag", Placement::Before, "table");
+    })->toThrow(ItemNotFoundException::class, "No item match the value");
+});
+
+test("throws exception if reordering an item before one that does not exist", function (): void {
+    $listing = Listing::from([
+        new Item("bag", 1),
+    ]);
+
+    expect(function () use ($listing): void {
+        $listing->reorder("bag", Placement::Before, "table");
+    })->toThrow(ItemNotFoundException::class, "No item match the value");
 });


### PR DESCRIPTION
## Added

- Reording items using `Listing::reorder()` now takes the raw value used to build the `Item` instead of an instanc of `Item`