### PR TITLE
15-specify-how-items-should-match-another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ability to specify how to match values together ([#15](https://github.com/khalyomede/reorder-before-after/issues/15)).
+
 ## [0.2.0] - 2023-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ composer require khalyomede/reorder-before-after
 - [5. Getting all items from a listing](#5-getting-all-items-from-a-listing)
 - [6. Use a callback to apply the order on your value](#6-use-a-callback-to-apply-the-order-on-your-value)
 - [7. Create a listing from values and specify how to retrieve the order using a callback](#7-create-a-listing-from-values-and-specify-how-to-retrieve-the-order-using-a-callback)
+- [8. Specify how to match items together](#8-specify-how-to-match-items-together)
 
 ### 1. Moving an item before another
 
@@ -218,6 +219,24 @@ use Khalyomede\ReorderBeforeAfter\Listing;
 
 $products = Product::all();
 $listing = Listing::outOf($products, fn (Product $product): Item => new Item($product, $product->order));
+```
+
+### 8. Specify how to match items together
+
+In this example, we will instruct the listing how it should match our objects. Useful if your objects can contain different set of data, making the whole object different, when in reality both are equal (matching by id).
+
+This examples features an hypothetical `Product` [Eloquent](https://laravel.com/docs/master/eloquent) model, where one of the two can have more attributes (like eager loaded relationships), making the triple equal check invalid.
+
+```php
+use App\Models\Product;
+use Khalyomede\ReorderBeforeAfter\Listing;
+
+$listing = Listing::outOf(Product::all(), fn (Product $product): Item => new Item($product, $product->order));
+
+$listing->matchWith(fn (Product $left, Product $right): bool => $left->id === $right->id);
+
+// Or with the shorter Eloquent::is() method
+$listing->matchWith(fn (Product $left, Product $right): bool => $left->is($right));
 ```
 
 ## Tests

--- a/rector.php
+++ b/rector.php
@@ -10,6 +10,8 @@ use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 use Rector\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -24,6 +26,12 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveNonExistingVarAnnotationRector::class,
         RemoveLastReturnRector::class,
         ChangeReadOnlyVariableWithDefaultValueToConstantRector::class,
+        ReturnTypeFromStrictTypedCallRector::class => [
+            __DIR__ . "/tests/ReorderTest.php",
+        ],
+        AddArrowFunctionReturnTypeRector::class => [
+            __DIR__ . "/tests/ReorderTest.php",
+        ],
     ]);
 
     // define sets of rules

--- a/src/Exceptions/InvalidMatchWithCallback.php
+++ b/src/Exceptions/InvalidMatchWithCallback.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Khalyomede\ReorderBeforeAfter\Exceptions;
+
+use Exception;
+
+final class InvalidMatchWithCallbackException extends Exception
+{
+}

--- a/src/Exceptions/InvalidMatchWithCallbackException.php
+++ b/src/Exceptions/InvalidMatchWithCallbackException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Khalyomede\ReorderBeforeAfter\Exceptions;
 
 use Exception;

--- a/tests/ReorderTest.php
+++ b/tests/ReorderTest.php
@@ -289,10 +289,20 @@ test("can specify how to match items together", function (): void {
 
     $listing->matchWith(fn (Product $left, Product $right): bool => $left->name === $right->name);
 
-    expect($listing->find($bag)->value->name)->toBe("bag");
-    expect($listing->find($book)->value->name)->toBe("book");
-    expect($listing->find($chair)->value->name)->toBe("chair");
-    expect($listing->find($table)->value->name)->toBe("table");
+    $foundBag = $listing->find($bag)->value;
+    $foundBook = $listing->find($book)->value;
+    $foundChair = $listing->find($chair)->value;
+    $foundTable = $listing->find($table)->value;
+
+    assert($foundBag instanceof Product);
+    assert($foundBook instanceof Product);
+    assert($foundChair instanceof Product);
+    assert($foundTable instanceof Product);
+
+    expect($foundBag->name)->toBe("bag");
+    expect($foundBook->name)->toBe("book");
+    expect($foundChair->name)->toBe("chair");
+    expect($foundTable->name)->toBe("table");
 });
 
 test("throws an exception if the callback used to specify how to match items together does not specify a bool return type", function (): void {
@@ -300,5 +310,5 @@ test("throws an exception if the callback used to specify how to match items tog
 
     expect(function () use ($listing): void {
         $listing->matchWith(fn (mixed $left, mixed $right) => $left === $right);
-    })->toThrow(InvalidMatchWithCallbackException::class, "Your callback must have a bool return type hint");
+    })->toThrow(InvalidMatchWithCallbackException::class, "Your callback must have a bool return type");
 });

--- a/tests/ReorderTest.php
+++ b/tests/ReorderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Khalyomede\ReorderBeforeAfter\Exceptions\BadOutOfCallbackException;
 use Khalyomede\ReorderBeforeAfter\Exceptions\InvalidApplyWithCallbackException;
+use Khalyomede\ReorderBeforeAfter\Exceptions\InvalidMatchWithCallbackException;
 use Khalyomede\ReorderBeforeAfter\Exceptions\ItemNotFoundException;
 use Khalyomede\ReorderBeforeAfter\Item;
 use Khalyomede\ReorderBeforeAfter\Listing;
@@ -274,4 +275,30 @@ test("throws exception if the callback used to create a list out of objects spec
     expect(function (): void {
         Listing::outOf([], fn ($value): string => "");
     })->toThrow(BadOutOfCallbackException::class, "Your callback must have an Item return type hint");
+});
+
+test("can specify how to match items together", function (): void {
+    $bag = new Product(name: "bag", quantity: 12, unitPrice: 19.99, order: 1);
+    $book = new Product(name: "book", quantity: 12, unitPrice: 99.99, order: 2);
+    $chair = new Product(name: "chair", quantity: 12, unitPrice: 39.99, order: 3);
+    $table = new Product(name: "table", quantity: 12, unitPrice: 29.99, order: 4);
+
+    $products = [$bag, $book, $chair, $table];
+
+    $listing = Listing::outOf($products, fn (Product $product): Item => new Item($product, $product->order));
+
+    $listing->matchWith(fn (Product $left, Product $right): bool => $left->name === $right->name);
+
+    expect($listing->find($bag)->value->name)->toBe("bag");
+    expect($listing->find($book)->value->name)->toBe("book");
+    expect($listing->find($chair)->value->name)->toBe("chair");
+    expect($listing->find($table)->value->name)->toBe("table");
+});
+
+test("throws an exception if the callback used to specify how to match items together does not specify a bool return type", function (): void {
+    $listing = new Listing();
+
+    expect(function () use ($listing): void {
+        $listing->matchWith(fn (mixed $left, mixed $right) => $left === $right);
+    })->toThrow(InvalidMatchWithCallbackException::class, "Your callback must have a bool return type hint");
 });


### PR DESCRIPTION
## Added

- New method `Listing::matchWith()` to specify how to match two items together

## Fixed

N/A

## Breaking

N/A