### PR TITLE
17-rename-bad-out-of-callback-exception-invalid-out-of-callback-exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ability to specify how to match values together ([#15](https://github.com/khalyomede/reorder-before-after/issues/15)).
 
+### Breaking
+
+- The "BadOutOfCallbackException" has been renamed to "InvalidOutOfCallbackException" to match the other similar exceptions prefixes ([#17](https://github.com/khalyomede/reorder-before-after/issues/17)).
+
 ## [0.2.0] - 2023-01-14
 
 ### Added

--- a/src/Exceptions/InvalidOutOfCallbackException.php
+++ b/src/Exceptions/InvalidOutOfCallbackException.php
@@ -6,6 +6,6 @@ namespace Khalyomede\ReorderBeforeAfter\Exceptions;
 
 use Exception;
 
-final class BadOutOfCallbackException extends Exception
+final class InvalidOutOfCallbackException extends Exception
 {
 }

--- a/src/Listing.php
+++ b/src/Listing.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Khalyomede\ReorderBeforeAfter;
 
 use Closure;
-use Khalyomede\ReorderBeforeAfter\Exceptions\BadOutOfCallbackException;
 use Khalyomede\ReorderBeforeAfter\Exceptions\InvalidApplyWithCallbackException;
 use Khalyomede\ReorderBeforeAfter\Exceptions\InvalidMatchWithCallbackException;
+use Khalyomede\ReorderBeforeAfter\Exceptions\InvalidOutOfCallbackException;
 use Khalyomede\ReorderBeforeAfter\Exceptions\ItemNotFoundException;
 use Khalyomede\ReorderBeforeAfter\Exceptions\TooManyItemsException;
 use ReflectionFunction;
@@ -241,7 +241,7 @@ final class Listing
         $returnType = $reflection->getReturnType();
 
         if (!($returnType instanceof ReflectionNamedType) || $returnType->getName() !== Item::class) {
-            throw new BadOutOfCallbackException("Your callback must have an Item return type hint");
+            throw new InvalidOutOfCallbackException("Your callback must have an Item return type hint");
         }
     }
 }

--- a/tests/ReorderTest.php
+++ b/tests/ReorderTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Khalyomede\ReorderBeforeAfter\Exceptions\BadOutOfCallbackException;
 use Khalyomede\ReorderBeforeAfter\Exceptions\InvalidApplyWithCallbackException;
 use Khalyomede\ReorderBeforeAfter\Exceptions\InvalidMatchWithCallbackException;
+use Khalyomede\ReorderBeforeAfter\Exceptions\InvalidOutOfCallbackException;
 use Khalyomede\ReorderBeforeAfter\Exceptions\ItemNotFoundException;
 use Khalyomede\ReorderBeforeAfter\Item;
 use Khalyomede\ReorderBeforeAfter\Listing;
@@ -274,7 +274,7 @@ test("it creates a listing out of an array of object", function (): void {
 test("throws exception if the callback used to create a list out of objects specify a wrong type hint", function (): void {
     expect(function (): void {
         Listing::outOf([], fn ($value): string => "");
-    })->toThrow(BadOutOfCallbackException::class, "Your callback must have an Item return type hint");
+    })->toThrow(InvalidOutOfCallbackException::class, "Your callback must have an Item return type hint");
 });
 
 test("can specify how to match items together", function (): void {


### PR DESCRIPTION
## Added

N/A

## Fixed

N/A

## Breaking

- Exception `BadOutOfCallbackException` has been renamed to `InvalidOutOfCallbackException` to follow the other similars exceptions prefixes