### PR TITLE
16-add-php-stan-type-hints-for-callbacks-of-listing-out-of-listing-match-with-and-listing-apply-with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ability to specify how to match values together ([#15](https://github.com/khalyomede/reorder-before-after/issues/15)).
+- Typehints on closures for `Listing::outOf()` `Listing::applyWith()` and `Listing::matchWith()` ([#16](https://github.com/khalyomede/reorder-before-after/issues/16)).
 
 ### Breaking
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,4 @@ parameters:
         - '#Pest#'
     excludePaths:
         - tests/Pest.php
+    checkExplicitMixed: false

--- a/src/Listing.php
+++ b/src/Listing.php
@@ -20,8 +20,14 @@ final class Listing
      */
     private array $items;
 
+    /**
+     * @var Closure(Item): void
+     */
     private Closure $applyWith;
 
+    /**
+     * @var Closure(mixed, mixed): bool
+     */
     private Closure $matchWith;
 
     public function __construct()
@@ -48,6 +54,7 @@ final class Listing
 
     /**
      * @param array<mixed> $values
+     * @param Closure(mixed): Item $callback
      */
     public static function outOf(array $values, Closure $callback): self
     {
@@ -116,6 +123,9 @@ final class Listing
         return $item;
     }
 
+    /**
+     * @param Closure(Item): void $callback
+     */
     public function applyWith(Closure $callback): void
     {
         $reflection = new ReflectionFunction($callback);
@@ -141,6 +151,9 @@ final class Listing
         $this->applyWith = $callback;
     }
 
+    /**
+     * @param Closure(mixed, mixed): bool $callback
+     */
     public function matchWith(Closure $callback): void
     {
         self::checkMatchWithCallbackSignature($callback);

--- a/tests/ReorderTest.php
+++ b/tests/ReorderTest.php
@@ -217,6 +217,7 @@ test("throws exception if the apply with a callback without parameters", functio
     $listing = new Listing();
 
     expect(function () use ($listing): void {
+        /** @phpstan-ignore-next-line */
         $listing->applyWith(fn (): int => 1);
     })->toThrow(InvalidApplyWithCallbackException::class, "Your callback must have exactly one parameter");
 });
@@ -225,6 +226,7 @@ test("throws exception if the apply with a callback without type hint", function
     $listing = new Listing();
 
     expect(function () use ($listing): void {
+        /** @phpstan-ignore-next-line */
         $listing->applyWith(fn ($item): int => 1);
     })->toThrow(InvalidApplyWithCallbackException::class, "Your callback must be type hinted with " . Item::class);
 });
@@ -233,6 +235,7 @@ test("throws exception if the apply with a callback without Item type hint", fun
     $listing = new Listing();
 
     expect(function () use ($listing): void {
+        /** @phpstan-ignore-next-line */
         $listing->applyWith(fn (Product $item): int => 1);
     })->toThrow(InvalidApplyWithCallbackException::class, "Your callback must be type hinted with " . Item::class);
 });
@@ -273,6 +276,7 @@ test("it creates a listing out of an array of object", function (): void {
 
 test("throws exception if the callback used to create a list out of objects specify a wrong type hint", function (): void {
     expect(function (): void {
+        /** @phpstan-ignore-next-line */
         Listing::outOf([], fn ($value): string => "");
     })->toThrow(InvalidOutOfCallbackException::class, "Your callback must have an Item return type hint");
 });


### PR DESCRIPTION
## Added

- Typehints for all callbacks: `Listing::applyWith()` `Listing::outOf()` and `Listing::matchWith()`

## Fixed

N/A

## Breaking

N/A